### PR TITLE
修改文档描述错误

### DIFF
--- a/doc/1、开发环境搭建.md
+++ b/doc/1、开发环境搭建.md
@@ -110,7 +110,7 @@
 
 
 
-【注意】由于本项目以来中间件比较多，在非linux上启动docker可能会消耗内存较多，建议将物理机分配给docker的内存调到8G
+【注意】由于本项目本来中间件比较多，在非linux上启动docker可能会消耗内存较多，建议将物理机分配给docker的内存调到8G
 
 
 
@@ -439,7 +439,7 @@ $  sed -i "" 's/,omitempty//g'  ./rpc/pb/*.pb.go
 
 - api项目中的.api文件我们做了拆分，统一放到每个api的desc文件夹下，因为如果所有内容都写在api中可能不便于查看，所以做了拆分，把所有方法写到一个api中，其他的实体以及req、rep统一放到一个文件夹单独定义比较清晰
 
-- 生成model、错误处理时候使用了template重新定义，该项目用到的自定义的goctl的模版在项目data/goctl下
+- 生成model、错误处理时候使用了template重新定义，该项目用到的自定义的goctl的模版在项目deploy/goctl下
 
 
 


### PR DESCRIPTION
【由于本项目以来中间件比较多】改为【由于本项目本来中间件比较多】
【该项目用到的自定义的goctl的模版在项目data/goctl下】改为【该项目用到的自定义的goctl的模版在项目deploy/goctl下】