### PR TITLE
fix wechat pay callback err handler

### DIFF
--- a/app/payment/cmd/api/internal/logic/thirdPayment/thirdPaymentWxPayCallbackLogic.go
+++ b/app/payment/cmd/api/internal/logic/thirdPayment/thirdPaymentWxPayCallbackLogic.go
@@ -59,7 +59,8 @@ func (l *ThirdPaymentWxPayCallbackLogic) ThirdPaymentWxPayCallback(rw http.Respo
 	}
 
 	returnCode := "SUCCESS"
-	if err := l.verifyAndUpdateState(transaction); err != nil {
+	err = l.verifyAndUpdateState(transaction)
+	if err != nil {
 		returnCode = "FAIL"
 	}
 


### PR DESCRIPTION
fix handler err is nil when logic verifyAndUpdateState func return err. cause handler http status code is ok

修复 verifyAndUpdateState 返回错误时 handler 接收的 err 为 nil, 导致 http status code 为 200. 让微信通知方误认为回调成功。