### PR TITLE
fix default branch links

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -2,7 +2,7 @@
 
 ## go-zero-looklook
 
-[English](https://github.com/Mikaelemmmm/go-zero-looklook/blob/master/README.md) | 简体中文
+[English](https://github.com/Mikaelemmmm/go-zero-looklook/blob/main/README.md) | 简体中文
 
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## go-zero-looklook
 
-English | [简体中文](https://github.com/Mikaelemmmm/go-zero-looklook/blob/master/README-cn.md)
+English | [简体中文](https://github.com/Mikaelemmmm/go-zero-looklook/blob/main/README-cn.md)
 
 
 


### PR DESCRIPTION
Replace https://github.com/Mikaelemmmm/go-zero-looklook/blob/master
  with https://github.com/Mikaelemmmm/go-zero-looklook/blob/main