### PR TITLE
fix: kafka create topic

### DIFF
--- a/doc/chinese/01-开发环境搭建.md
+++ b/doc/chinese/01-开发环境搭建.md
@@ -148,8 +148,8 @@ $ cd /opt/kafka/bin/
 创建2个topic
 
 ```shell
-$ ./kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 -partitions 1 --topic looklook-log
-$ ./kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 -partitions 1 --topic payment-update-paystatus-topic
+$ ./kafka-topics.sh --create --bootstrap-server localhost:9094 --replication-factor 1 --partitions 1 --topic looklook-log
+$ ./kafka-topics.sh --create --bootstrap-server localhost:9094 --replication-factor 1 --partitions 1 --topic payment-update-paystatus-topic
 ```
 
 looklook-log ： 日志收集使用的

--- a/doc/english/01-Development-environment-setup.md
+++ b/doc/english/01-Development-environment-setup.md
@@ -140,8 +140,8 @@ cd /opt/kafka/bin/
 Create 3 topics
 
 ```shell
-./kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 -partitions 1 --topic looklook-log
-./kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 -partitions 1 --topic payment-update-paystatus-topic
+$ ./kafka-topics.sh --create --bootstrap-server localhost:9094 --replication-factor 1 --partitions 1 --topic looklook-log
+$ ./kafka-topics.sh --create --bootstrap-server localhost:9094 --replication-factor 1 --partitions 1 --topic payment-update-paystatus-topic
 ```
 
 looklook-log : The log collection uses the


### PR DESCRIPTION
该项目使用的是 apache/kafka:3.9.0 版本，这个版本已经完全支持 KRaft 模式，不需要 ZooKeeper。
1. 使用 --bootstrap-server 替换 --zookeeper
2. 服务地址 localhost:9094 替换 zookeeper:2181