### PR TITLE
Fix: usercenter rpc register logic

### DIFF
--- a/app/usercenter/cmd/rpc/internal/logic/registerLogic.go
+++ b/app/usercenter/cmd/rpc/internal/logic/registerLogic.go
@@ -42,7 +42,7 @@ func (l *RegisterLogic) Register(in *usercenter.RegisterReq) (*usercenter.Regist
 	if err := l.svcCtx.UserModel.Trans(l.ctx, func(ctx context.Context, session sqlx.Session) error {
 		user := new(model.User)
 		user.Mobile = in.Mobile
-		if len(user.Nickname) == 0 {
+		if len(in.Nickname) == 0 {
 			user.Nickname = tool.Krand(8, tool.KC_RAND_KIND_ALL)
 		}
 		if len(in.Password) > 0 {


### PR DESCRIPTION
user是新new的，user.Nickname必为空。看这里的意图应该是rpc传入的昵称为空时，随机生成一个昵称。